### PR TITLE
Update fs.js

### DIFF
--- a/src/fs.js
+++ b/src/fs.js
@@ -566,7 +566,9 @@ var fsExtended = {
                 defer.resolve.apply(defer, args);
             }
         };
-        promiseFunction.name = methodName + 'Promise';
+        try {
+            promiseFunction.name = methodName + 'Promise';
+        } catch (e) {}
 
         return promiseFunction;
     }

--- a/src/fs.js
+++ b/src/fs.js
@@ -566,9 +566,6 @@ var fsExtended = {
                 defer.resolve.apply(defer, args);
             }
         };
-        try {
-            promiseFunction.name = methodName + 'Promise';
-        } catch (e) {}
 
         return promiseFunction;
     }


### PR DESCRIPTION
In new versions of Node (tested in v. 0.11.13), `Function.name` is a read-only property ([it is likely to stay this way](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name)), assigning a value to it causes an error in strict mode.
I presume that this is only for debugging reasons, so I left the catch clause empty.
