### PR TITLE
Fixed delegating errors to callbacks

### DIFF
--- a/src/fs.js
+++ b/src/fs.js
@@ -328,6 +328,7 @@ var fsExtended = {
                     fs.stat(dest, function(error, stats) {
                         if (error) {
                             callback(error);
+                            return;
                         }
 
                         if (stats.isDirectory()) {
@@ -343,11 +344,13 @@ var fsExtended = {
                 function makeDestDir(error) {
                     if (error) {
                         callback(error);
+                        return;
                     }
 
                     fs.mkdir(dest, function(error) {
                         if (error) {
                             callback(error);
+                            return;
                         }
 
                         fs.readdir(src, function(error, files) {


### PR DESCRIPTION
In few places, after callback was called with error, the function was running further, causing unexpedted actions.

Please check line 563. Although the function’s name is `resolveIfNoError`, the error is handled and there is no `return` after promise rejection. I'm not sure if it should be ther or not, so I leave it to you.
